### PR TITLE
Refactor: Split Functions from main.rs into Separate Files

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,4 @@
+pub const VERSION: &str = "1.0.0";
+pub const SPACE: [char; 5] = [' ', '　', '\n', '\t', '\r'];
+
+

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,108 @@
+use crate::{
+    types,
+    type_enum::Type,
+    state
+};
+use rustyline::DefaultEditor;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub struct Engine {
+    pub scope: types::Scope,
+}
+
+impl Engine {
+    pub fn new() -> Engine {
+        Engine {
+            scope: BTreeMap::from([("new-line".to_string(), Type::Text("\n".to_string()))]),
+        }
+    }
+
+    pub fn run_program(&mut self, program: types::Program) -> Option<Type> {
+        let mut result = Type::Null;
+        for code in program {
+            result = self.run_opecode(code)?;
+        }
+        Some(result)
+    }
+
+    pub fn run_opecode(&mut self, code: state::Statement) -> Option<Type> {
+        match code {
+            state::Statement::Print(expr) => {
+                print!("{}", expr.eval(self)?.get_text());
+                Some(Type::Null)
+            }
+            state::Statement::Input(expr) => {
+                let prompt = expr.eval(self)?.get_text();
+                Some(Type::Text(
+                    DefaultEditor::new()
+                        .and_then(|mut rl| rl.readline(&prompt))
+                        .unwrap_or_default(),
+                ))
+            }
+            state::Statement::Cast(expr, to) => match to.as_str() {
+                "number" => {
+                    if let Ok(n) = expr.eval(self)?.get_text().parse() {
+                        Some(Type::Number(n))
+                    } else {
+                        None
+                    }
+                }
+                "text" => Some(Type::Text(expr.eval(self)?.get_text())),
+                "symbol" => Some(Type::Symbol(expr.eval(self)?.get_symbol())),
+                _ => None,
+            },
+            state::Statement::Let(name, expr) => {
+                let val = expr.eval(&mut self.clone())?;
+                self.scope.insert(name, val.clone());
+                Some(val)
+            }
+            state::Statement::If(expr, then, r#else) => {
+                if let Some(it) = expr.eval(self) {
+                    self.scope.insert("it".to_string(), it);
+                    then.eval(self)
+                } else {
+                    if let Some(r#else) = r#else {
+                        r#else.eval(self)
+                    } else {
+                        Some(Type::Null)
+                    }
+                }
+            }
+            state::Statement::While(expr, code) => {
+                let mut result = Type::Null;
+                while let Some(it) = expr.eval(self) {
+                    self.scope.insert("it".to_string(), it);
+                    result = code.eval(self)?;
+                }
+                Some(result)
+            }
+            state::Statement::Lambda(args, code) => {
+                let func_obj = Type::Function(args, Box::new(code));
+                Some(func_obj)
+            }
+            state::Statement::Define(name, args, code) => {
+                let func_obj = Type::Function(args, Box::new(code));
+                self.scope.insert(name, func_obj.clone());
+                Some(func_obj)
+            }
+            state::Statement::Call(func, value_args) => {
+                let func = func.eval(self);
+                if let Some(Type::Function(func_args, code)) = func {
+                    if func_args.len() != value_args.len() {
+                        return None;
+                    }
+
+                    for (arg, val) in func_args.iter().zip(value_args) {
+                        let val = val.eval(self)?;
+                        self.scope.insert(arg.to_string(), val);
+                    }
+                    code.eval(self)
+                } else {
+                    func
+                }
+            }
+            state::Statement::Fault => None,
+        }
+    }
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,0 +1,33 @@
+use crate::{
+    types,
+    engine,
+    infix::Infix,
+    type_enum::Type
+};
+
+#[derive(Debug, Clone)]
+pub enum Expr {
+    Infix(Box<Infix>),
+    Block(types::Program),
+    Value(Type),
+}
+
+impl Expr {
+    pub fn eval(&self, engine: &mut engine::Engine) -> Option<Type> {
+        Some(match self {
+            Expr::Infix(infix) => (*infix).eval(engine)?,
+            Expr::Block(block) => engine.run_program(block.clone())?,
+            Expr::Value(value) => {
+                if let Type::Symbol(name) = value {
+                    if let Some(refer) = engine.scope.get(name.as_str()) {
+                        refer.clone()
+                    } else {
+                        value.clone()
+                    }
+                } else {
+                    value.clone()
+                }
+            }
+        })
+    }
+}

--- a/src/infix.rs
+++ b/src/infix.rs
@@ -1,0 +1,108 @@
+use crate::{
+    operator::Operator,
+    expr,
+    engine,
+    type_enum::Type
+};
+
+#[derive(Debug, Clone)]
+pub struct Infix {
+    pub operator: Operator,
+    pub values: (expr::Expr, expr::Expr),
+}
+
+impl Infix {
+    pub fn eval(&self, engine: &mut engine::Engine) -> Option<Type> {
+        let left = self.values.0.eval(engine);
+        let right = self.values.1.eval(engine);
+
+        Some(match self.operator {
+            Operator::Add => {
+                if let (Some(Type::Number(left)), Some(Type::Number(right))) = (&left, &right) {
+                    Type::Number(left + right)
+                } else if let (Some(Type::Text(left)), Some(Type::Text(right))) = (left, right) {
+                    Type::Text(left + &right)
+                } else {
+                    return None;
+                }
+            }
+            Operator::Sub => {
+                if let (Some(Type::Number(left)), Some(Type::Number(right))) = (&left, &right) {
+                    Type::Number(left - right)
+                } else if let (Some(Type::Text(left)), Some(Type::Text(right))) = (left, right) {
+                    Type::Text(left.replace(&right, ""))
+                } else {
+                    return None;
+                }
+            }
+            Operator::Mul => {
+                if let (Some(Type::Number(left)), Some(Type::Number(right))) = (&left, &right) {
+                    Type::Number(left * right)
+                } else if let (Some(Type::Text(left)), Some(Type::Number(right))) = (left, right) {
+                    Type::Text(left.repeat(right as usize))
+                } else {
+                    return None;
+                }
+            }
+            Operator::Div => Type::Number(left?.get_number() / right?.get_number()),
+            Operator::Mod => Type::Number(left?.get_number() % right?.get_number()),
+            Operator::Pow => Type::Number(left?.get_number().powf(right?.get_number())),
+            Operator::Equal => {
+                if left?.get_symbol() == right.clone()?.get_symbol() {
+                    right?
+                } else {
+                    return None;
+                }
+            }
+            Operator::NotEq => {
+                if left?.get_symbol() != right.clone()?.get_symbol() {
+                    right?
+                } else {
+                    return None;
+                }
+            }
+            Operator::LessThan => {
+                if left.clone()?.get_number() < right.clone()?.get_number() {
+                    right?
+                } else {
+                    return None;
+                }
+            }
+            Operator::LessThanEq => {
+                if left?.get_number() <= right.clone()?.get_number() {
+                    right?
+                } else {
+                    return None;
+                }
+            }
+            Operator::GreaterThan => {
+                if left?.get_number() > right.clone()?.get_number() {
+                    right?
+                } else {
+                    return None;
+                }
+            }
+            Operator::GreaterThanEq => {
+                if left?.get_number() >= right.clone()?.get_number() {
+                    right?
+                } else {
+                    return None;
+                }
+            }
+            Operator::And => {
+                if left.is_some() && right.is_some() {
+                    right?
+                } else {
+                    return None;
+                }
+            }
+            Operator::Or => {
+                if left.is_some() || right.is_none() {
+                    right.unwrap_or(left?)
+                } else {
+                    return None;
+                }
+            }
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,22 @@
 use clap::Parser;
 use rustyline::DefaultEditor;
-use std::{collections::BTreeMap, fs::read_to_string};
+use std::fs;
 
-const VERSION: &str = "1.0.0";
-const SPACE: [char; 5] = [' ', '　', '\n', '\t', '\r'];
+mod parse_expr;
+mod consts;
+mod tokenize;
+mod parse;
+mod types;
+mod state;
+mod engine;
+mod expr;
+mod infix;
+mod operator;
+mod type_enum;
+
 
 #[derive(Parser, Debug)]
-#[command(name = "idol", version = VERSION, about = "Goal-directed evaluation programming language inspired by Icon")]
+#[command(name = "idol", version = consts::VERSION, about = "Goal-directed evaluation programming language inspired by Icon")]
 struct Cli {
     /// Script file to be running
     #[arg(index = 1)]
@@ -19,11 +29,11 @@ struct Cli {
 
 fn main() {
     let cli = Cli::parse();
-    let mut engine = Engine::new();
+    let mut engine = engine::Engine::new();
 
     if let Some(path) = cli.file {
-        if let Ok(code) = read_to_string(path) {
-            if let Some(ast) = parse_program(code) {
+        if let Ok(code) = fs::read_to_string(path) {
+            if let Some(ast) = parse::parse_program(code) {
                 if cli.debug {
                     println!("{ast:?}")
                 }
@@ -38,8 +48,8 @@ fn main() {
 }
 
 fn repl(debug: bool) {
-    println!("idol {VERSION}");
-    let mut engine = Engine::new();
+    println!("idol {}", consts::VERSION);
+    let mut engine = engine::Engine::new();
     let mut rl = DefaultEditor::new().unwrap();
     loop {
         match rl.readline("> ") {
@@ -52,7 +62,7 @@ fn repl(debug: bool) {
                 }
 
                 rl.add_history_entry(&code).unwrap_or_default();
-                if let Some(ast) = parse_program(code) {
+                if let Some(ast) = parse::parse_program(code) {
                     if debug {
                         println!("AST = {ast:?}")
                     }
@@ -60,7 +70,7 @@ fn repl(debug: bool) {
                         if debug {
                             println!("Result = {:?}", result);
                         } else {
-                            if let Type::Null = result {
+                            if let type_enum::Type::Null = result {
                             } else {
                                 println!("{}", result.get_symbol());
                             }
@@ -77,510 +87,8 @@ fn repl(debug: bool) {
     }
 }
 
-fn parse_expr(soruce: String) -> Option<Expr> {
-    let token_list: Vec<String> = tokenize_expr(soruce, SPACE.to_vec())?;
-    let token = token_list.last()?.trim().to_string();
-    let token = if let Ok(n) = token.parse::<f64>() {
-        Expr::Value(Type::Number(n))
-    } else if token.starts_with('(') && token.ends_with(')') {
-        let token = {
-            let mut token = token.clone();
-            token.remove(0);
-            token.remove(token.len() - 1);
-            token
-        };
-        parse_expr(token)?
-    } else if token.starts_with('{') && token.ends_with('}') {
-        let token = {
-            let mut token = token.clone();
-            token.remove(0);
-            token.remove(token.len() - 1);
-            token
-        };
-        Expr::Block(parse_program(token)?)
-    } else if token.starts_with('"') && token.ends_with('"') {
-        let token = {
-            let mut token = token.clone();
-            token.remove(0);
-            token.remove(token.len() - 1);
-            token
-        };
-        Expr::Value(Type::Text(token))
-    } else {
-        Expr::Value(Type::Symbol(token))
-    };
 
-    if let Some(operator) = token_list
-        .len()
-        .checked_sub(2)
-        .and_then(|idx| token_list.get(idx))
-    {
-        let operator = match operator.as_str() {
-            "+" => Operator::Add,
-            "-" => Operator::Sub,
-            "*" => Operator::Mul,
-            "/" => Operator::Div,
-            "%" => Operator::Mod,
-            "^" => Operator::Pow,
-            "==" => Operator::Equal,
-            "!=" => Operator::NotEq,
-            "<" => Operator::LessThan,
-            "<=" => Operator::LessThanEq,
-            ">" => Operator::GreaterThan,
-            ">=" => Operator::GreaterThanEq,
-            "&" => Operator::And,
-            "|" => Operator::Or,
-            _ => return None,
-        };
-        Some(Expr::Infix(Box::new(Infix {
-            operator,
-            values: (
-                parse_expr(token_list.get(..token_list.len() - 2)?.to_vec().join(" "))?,
-                token,
-            ),
-        })))
-    } else {
-        return Some(token);
-    }
-}
 
-fn tokenize_expr(input: String, delimiter: Vec<char>) -> Option<Vec<String>> {
-    let mut tokens: Vec<String> = Vec::new();
-    let mut current_token = String::new();
-    let mut in_parentheses: usize = 0;
-    let mut in_quote = false;
 
-    for c in input.chars() {
-        match c {
-            '(' | '{' | '[' if !in_quote => {
-                current_token.push(c);
-                in_parentheses += 1;
-            }
-            ')' | '}' | ']' if !in_quote => {
-                current_token.push(c);
-                if in_parentheses > 0 {
-                    in_parentheses -= 1;
-                } else {
-                    return None;
-                }
-            }
-            '"' => {
-                in_quote = !in_quote;
-                current_token.push(c);
-            }
-            other => {
-                if delimiter.contains(&other) && !in_quote {
-                    if in_parentheses != 0 {
-                        current_token.push(c);
-                    } else if !current_token.is_empty() {
-                        tokens.push(current_token.clone());
-                        current_token.clear();
-                    }
-                } else {
-                    current_token.push(c);
-                }
-            }
-        }
-    }
 
-    // Syntax error check
-    if in_quote || in_parentheses != 0 {
-        return None;
-    }
 
-    if in_parentheses == 0 && !current_token.is_empty() {
-        tokens.push(current_token.clone());
-        current_token.clear();
-    }
-
-    Some(tokens)
-}
-
-fn parse_program(source: String) -> Option<Program> {
-    let mut program: Program = Vec::new();
-    for line in tokenize_expr(source, vec![';'])? {
-        let line = line.trim().to_string();
-        if line.is_empty() {
-            continue;
-        }
-        program.push(parse_opecode(line.trim().to_string())?);
-    }
-    Some(program)
-}
-
-fn parse_opecode(code: String) -> Option<Statement> {
-    let code = code.trim();
-    Some(if code.starts_with("print") {
-        Statement::Print(parse_expr(code["print".len()..].to_string())?)
-    } else if code.starts_with("input") {
-        Statement::Input(parse_expr(code["input".len()..].to_string())?)
-    } else if code.starts_with("cast") {
-        let code = code["cast".len()..].to_string();
-        let (expr, r#type) = {
-            let splited = code.split("to").collect::<Vec<&str>>();
-            (
-                parse_expr(splited.get(..splited.len() - 1)?.to_vec().join("to"))?,
-                splited.last()?.trim().to_string(),
-            )
-        };
-        Statement::Cast(expr, r#type)
-    } else if code.starts_with("if") {
-        let code = code["if".len()..].to_string();
-        let code = tokenize_expr(code, SPACE.to_vec())?;
-        if code.get(2).and_then(|x| Some(x == "else")).unwrap_or(false) {
-            Statement::If(
-                parse_expr(code.get(0)?.to_string())?,
-                parse_expr(code.get(1)?.to_string())?,
-                Some(parse_expr(code.get(3)?.to_string())?),
-            )
-        } else {
-            Statement::If(
-                parse_expr(code.get(0)?.to_string())?,
-                parse_expr(code.get(1)?.to_string())?,
-                None,
-            )
-        }
-    } else if code.starts_with("while") {
-        let code = code["while".len()..].to_string();
-        let code = tokenize_expr(code, SPACE.to_vec())?;
-        Statement::While(
-            parse_expr(code.get(0)?.to_string())?,
-            parse_expr(code.get(1)?.to_string())?,
-        )
-    } else if code.starts_with("func") {
-        let code = code["func".len()..].to_string();
-        let code = tokenize_expr(code, SPACE.to_vec())?;
-        let header = code.get(0)?.trim().to_string();
-        let header = tokenize_expr(header[1..header.len() - 1].to_string(), SPACE.to_vec())?;
-        Statement::Define(
-            header.get(0)?.to_string(),
-            header.get(1..)?.to_vec(),
-            parse_expr(code.get(1)?.to_string())?,
-        )
-    } else if code.starts_with("lambda") {
-        let code = code["lambda".len()..].to_string();
-        let code = tokenize_expr(code, SPACE.to_vec())?;
-        let header = code.get(0)?.trim().to_string();
-        let header = tokenize_expr(header[1..header.len() - 1].to_string(), SPACE.to_vec())?;
-        Statement::Lambda(header, parse_expr(code.get(1)?.to_string())?)
-    } else if code.starts_with("let") {
-        let code = code["let".len()..].to_string();
-        let (name, code) = code.split_once("=")?;
-        Statement::Let(name.trim().to_string(), parse_expr(code.to_string())?)
-    } else if code == "fault" {
-        Statement::Fault
-    } else {
-        let code = tokenize_expr(code.to_string(), SPACE.to_vec())?;
-        Statement::Call(
-            parse_expr(code.get(0)?.to_string())?,
-            code.get(1..)?
-                .to_vec()
-                .iter()
-                .map(|i| parse_expr(i.to_string()).unwrap_or(Expr::Value(Type::Null)))
-                .collect(),
-        )
-    })
-}
-
-type Scope = BTreeMap<String, Type>;
-type Program = Vec<Statement>;
-#[derive(Debug, Clone)]
-enum Statement {
-    Print(Expr),
-    Input(Expr),
-    Cast(Expr, String),
-    Let(String, Expr),
-    If(Expr, Expr, Option<Expr>),
-    While(Expr, Expr),
-    Lambda(Vec<String>, Expr),
-    Define(String, Vec<String>, Expr),
-    Call(Expr, Vec<Expr>),
-    Fault,
-}
-
-#[derive(Debug, Clone)]
-struct Engine {
-    scope: Scope,
-}
-
-impl Engine {
-    fn new() -> Engine {
-        Engine {
-            scope: BTreeMap::from([("new-line".to_string(), Type::Text("\n".to_string()))]),
-        }
-    }
-
-    fn run_program(&mut self, program: Program) -> Option<Type> {
-        let mut result = Type::Null;
-        for code in program {
-            result = self.run_opecode(code)?;
-        }
-        Some(result)
-    }
-
-    fn run_opecode(&mut self, code: Statement) -> Option<Type> {
-        match code {
-            Statement::Print(expr) => {
-                print!("{}", expr.eval(self)?.get_text());
-                Some(Type::Null)
-            }
-            Statement::Input(expr) => {
-                let prompt = expr.eval(self)?.get_text();
-                Some(Type::Text(
-                    DefaultEditor::new()
-                        .and_then(|mut rl| rl.readline(&prompt))
-                        .unwrap_or_default(),
-                ))
-            }
-            Statement::Cast(expr, to) => match to.as_str() {
-                "number" => {
-                    if let Ok(n) = expr.eval(self)?.get_text().parse() {
-                        Some(Type::Number(n))
-                    } else {
-                        None
-                    }
-                }
-                "text" => Some(Type::Text(expr.eval(self)?.get_text())),
-                "symbol" => Some(Type::Symbol(expr.eval(self)?.get_symbol())),
-                _ => None,
-            },
-            Statement::Let(name, expr) => {
-                let val = expr.eval(&mut self.clone())?;
-                self.scope.insert(name, val.clone());
-                Some(val)
-            }
-            Statement::If(expr, then, r#else) => {
-                if let Some(it) = expr.eval(self) {
-                    self.scope.insert("it".to_string(), it);
-                    then.eval(self)
-                } else {
-                    if let Some(r#else) = r#else {
-                        r#else.eval(self)
-                    } else {
-                        Some(Type::Null)
-                    }
-                }
-            }
-            Statement::While(expr, code) => {
-                let mut result = Type::Null;
-                while let Some(it) = expr.eval(self) {
-                    self.scope.insert("it".to_string(), it);
-                    result = code.eval(self)?;
-                }
-                Some(result)
-            }
-            Statement::Lambda(args, code) => {
-                let func_obj = Type::Function(args, Box::new(code));
-                Some(func_obj)
-            }
-            Statement::Define(name, args, code) => {
-                let func_obj = Type::Function(args, Box::new(code));
-                self.scope.insert(name, func_obj.clone());
-                Some(func_obj)
-            }
-            Statement::Call(func, value_args) => {
-                let func = func.eval(self);
-                if let Some(Type::Function(func_args, code)) = func {
-                    if func_args.len() != value_args.len() {
-                        return None;
-                    }
-
-                    for (arg, val) in func_args.iter().zip(value_args) {
-                        let val = val.eval(self)?;
-                        self.scope.insert(arg.to_string(), val);
-                    }
-                    code.eval(self)
-                } else {
-                    func
-                }
-            }
-            Statement::Fault => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum Type {
-    Number(f64),
-    Symbol(String),
-    Text(String),
-    Function(Vec<String>, Box<Expr>),
-    Null,
-}
-
-impl Type {
-    fn get_number(&self) -> f64 {
-        match self {
-            Type::Number(n) => n.to_owned(),
-            Type::Symbol(s) | Type::Text(s) => s.parse().unwrap_or(0.0),
-            Type::Null | Type::Function(_, _) => 0.0,
-        }
-    }
-
-    fn get_symbol(&self) -> String {
-        match self {
-            Type::Symbol(s) => s.to_string(),
-            Type::Text(s) => format!("\"{s}\""),
-            Type::Number(n) => n.to_string(),
-            Type::Null => "null".to_string(),
-            Type::Function(args, _) => {
-                format!("func ( {} )", args.join(SPACE[0].to_string().as_str()))
-            }
-        }
-    }
-
-    fn get_text(&self) -> String {
-        match self {
-            Type::Number(n) => n.to_string(),
-            Type::Symbol(s) | Type::Text(s) => s.to_string(),
-            Type::Null | Type::Function(_, _) => String::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum Expr {
-    Infix(Box<Infix>),
-    Block(Program),
-    Value(Type),
-}
-
-impl Expr {
-    fn eval(&self, engine: &mut Engine) -> Option<Type> {
-        Some(match self {
-            Expr::Infix(infix) => (*infix).eval(engine)?,
-            Expr::Block(block) => engine.run_program(block.clone())?,
-            Expr::Value(value) => {
-                if let Type::Symbol(name) = value {
-                    if let Some(refer) = engine.scope.get(name.as_str()) {
-                        refer.clone()
-                    } else {
-                        value.clone()
-                    }
-                } else {
-                    value.clone()
-                }
-            }
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-struct Infix {
-    operator: Operator,
-    values: (Expr, Expr),
-}
-
-#[derive(Debug, Clone)]
-enum Operator {
-    Add,
-    Sub,
-    Mul,
-    Div,
-    Mod,
-    Pow,
-    Equal,
-    NotEq,
-    LessThan,
-    LessThanEq,
-    GreaterThan,
-    GreaterThanEq,
-    And,
-    Or,
-}
-
-impl Infix {
-    fn eval(&self, engine: &mut Engine) -> Option<Type> {
-        let left = self.values.0.eval(engine);
-        let right = self.values.1.eval(engine);
-
-        Some(match self.operator {
-            Operator::Add => {
-                if let (Some(Type::Number(left)), Some(Type::Number(right))) = (&left, &right) {
-                    Type::Number(left + right)
-                } else if let (Some(Type::Text(left)), Some(Type::Text(right))) = (left, right) {
-                    Type::Text(left + &right)
-                } else {
-                    return None;
-                }
-            }
-            Operator::Sub => {
-                if let (Some(Type::Number(left)), Some(Type::Number(right))) = (&left, &right) {
-                    Type::Number(left - right)
-                } else if let (Some(Type::Text(left)), Some(Type::Text(right))) = (left, right) {
-                    Type::Text(left.replace(&right, ""))
-                } else {
-                    return None;
-                }
-            }
-            Operator::Mul => {
-                if let (Some(Type::Number(left)), Some(Type::Number(right))) = (&left, &right) {
-                    Type::Number(left * right)
-                } else if let (Some(Type::Text(left)), Some(Type::Number(right))) = (left, right) {
-                    Type::Text(left.repeat(right as usize))
-                } else {
-                    return None;
-                }
-            }
-            Operator::Div => Type::Number(left?.get_number() / right?.get_number()),
-            Operator::Mod => Type::Number(left?.get_number() % right?.get_number()),
-            Operator::Pow => Type::Number(left?.get_number().powf(right?.get_number())),
-            Operator::Equal => {
-                if left?.get_symbol() == right.clone()?.get_symbol() {
-                    right?
-                } else {
-                    return None;
-                }
-            }
-            Operator::NotEq => {
-                if left?.get_symbol() != right.clone()?.get_symbol() {
-                    right?
-                } else {
-                    return None;
-                }
-            }
-            Operator::LessThan => {
-                if left.clone()?.get_number() < right.clone()?.get_number() {
-                    right?
-                } else {
-                    return None;
-                }
-            }
-            Operator::LessThanEq => {
-                if left?.get_number() <= right.clone()?.get_number() {
-                    right?
-                } else {
-                    return None;
-                }
-            }
-            Operator::GreaterThan => {
-                if left?.get_number() > right.clone()?.get_number() {
-                    right?
-                } else {
-                    return None;
-                }
-            }
-            Operator::GreaterThanEq => {
-                if left?.get_number() >= right.clone()?.get_number() {
-                    right?
-                } else {
-                    return None;
-                }
-            }
-            Operator::And => {
-                if left.is_some() && right.is_some() {
-                    right?
-                } else {
-                    return None;
-                }
-            }
-            Operator::Or => {
-                if left.is_some() || right.is_none() {
-                    right.unwrap_or(left?)
-                } else {
-                    return None;
-                }
-            }
-        })
-    }
-}

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Clone)]
+pub enum Operator {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Pow,
+    Equal,
+    NotEq,
+    LessThan,
+    LessThanEq,
+    GreaterThan,
+    GreaterThanEq,
+    And,
+    Or,
+}
+
+

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,97 @@
+use crate::{
+    consts,
+    tokenize,
+    state::Statement,
+    parse_expr,
+    types,
+    expr::Expr,
+    type_enum::Type
+};
+
+
+pub fn parse_program(source: String) -> Option<types::Program> {
+    let mut program: types::Program = Vec::new();
+    for line in tokenize::tokenize_expr(source, vec![';'])? {
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+        program.push(parse_opecode(line.trim().to_string())?);
+    }
+    Some(program)
+}
+
+
+pub fn parse_opecode(code: String) -> Option<Statement> {
+    let code = code.trim();
+    Some(if code.starts_with("print") {
+        Statement::Print(parse_expr::parse_expr(code["print".len()..].to_string())?)
+    } else if code.starts_with("input") {
+        Statement::Input(parse_expr::parse_expr(code["input".len()..].to_string())?)
+    } else if code.starts_with("cast") {
+        let code = code["cast".len()..].to_string();
+        let (expr, r#type) = {
+            let splited = code.split("to").collect::<Vec<&str>>();
+            (
+                parse_expr::parse_expr(splited.get(..splited.len() - 1)?.to_vec().join("to"))?,
+                splited.last()?.trim().to_string(),
+            )
+        };
+        Statement::Cast(expr, r#type)
+    } else if code.starts_with("if") {
+        let code = code["if".len()..].to_string();
+        let code = tokenize::tokenize_expr(code, consts::SPACE.to_vec())?;
+        if code.get(2).and_then(|x| Some(x == "else")).unwrap_or(false) {
+            Statement::If(
+                parse_expr::parse_expr(code.get(0)?.to_string())?,
+                parse_expr::parse_expr(code.get(1)?.to_string())?,
+                Some(parse_expr::parse_expr(code.get(3)?.to_string())?),
+            )
+        } else {
+            Statement::If(
+                parse_expr::parse_expr(code.get(0)?.to_string())?,
+                parse_expr::parse_expr(code.get(1)?.to_string())?,
+                None,
+            )
+        }
+    } else if code.starts_with("while") {
+        let code = code["while".len()..].to_string();
+        let code = tokenize::tokenize_expr(code, consts::SPACE.to_vec())?;
+        Statement::While(
+            parse_expr::parse_expr(code.get(0)?.to_string())?,
+            parse_expr::parse_expr(code.get(1)?.to_string())?,
+        )
+    } else if code.starts_with("func") {
+        let code = code["func".len()..].to_string();
+        let code = tokenize::tokenize_expr(code, consts::SPACE.to_vec())?;
+        let header = code.get(0)?.trim().to_string();
+        let header = tokenize::tokenize_expr(header[1..header.len() - 1].to_string(), consts::SPACE.to_vec())?;
+        Statement::Define(
+            header.get(0)?.to_string(),
+            header.get(1..)?.to_vec(),
+            parse_expr::parse_expr(code.get(1)?.to_string())?,
+        )
+    } else if code.starts_with("lambda") {
+        let code = code["lambda".len()..].to_string();
+        let code = tokenize::tokenize_expr(code, consts::SPACE.to_vec())?;
+        let header = code.get(0)?.trim().to_string();
+        let header = tokenize::tokenize_expr(header[1..header.len() - 1].to_string(), consts::SPACE.to_vec())?;
+        Statement::Lambda(header, parse_expr::parse_expr(code.get(1)?.to_string())?)
+    } else if code.starts_with("let") {
+        let code = code["let".len()..].to_string();
+        let (name, code) = code.split_once("=")?;
+        Statement::Let(name.trim().to_string(), parse_expr::parse_expr(code.to_string())?)
+    } else if code == "fault" {
+        Statement::Fault
+    } else {
+        let code = tokenize::tokenize_expr(code.to_string(), consts::SPACE.to_vec())?;
+        Statement::Call(
+            parse_expr::parse_expr(code.get(0)?.to_string())?,
+            code.get(1..)?
+                .to_vec()
+                .iter()
+                .map(|i| parse_expr::parse_expr(i.to_string()).unwrap_or(Expr::Value(Type::Null)))
+                .collect(),
+        )
+    })
+}

--- a/src/parse_expr.rs
+++ b/src/parse_expr.rs
@@ -1,0 +1,78 @@
+use crate::{
+    expr::Expr,
+    operator::Operator,
+    type_enum::Type,
+    parse::parse_program,
+    consts::SPACE,
+    infix::Infix,
+    tokenize,
+
+};
+
+
+pub fn parse_expr(soruce: String) -> Option<Expr> {
+    let token_list: Vec<String> = tokenize::tokenize_expr(soruce, SPACE.to_vec())?;
+    let token = token_list.last()?.trim().to_string();
+    let token = if let Ok(n) = token.parse::<f64>() {
+        Expr::Value(Type::Number(n))
+    } else if token.starts_with('(') && token.ends_with(')') {
+        let token = {
+            let mut token = token.clone();
+            token.remove(0);
+            token.remove(token.len() - 1);
+            token
+        };
+        parse_expr(token)?
+    } else if token.starts_with('{') && token.ends_with('}') {
+        let token = {
+            let mut token = token.clone();
+            token.remove(0);
+            token.remove(token.len() - 1);
+            token
+        };
+        Expr::Block(parse_program(token)?)
+    } else if token.starts_with('"') && token.ends_with('"') {
+        let token = {
+            let mut token = token.clone();
+            token.remove(0);
+            token.remove(token.len() - 1);
+            token
+        };
+        Expr::Value(Type::Text(token))
+    } else {
+        Expr::Value(Type::Symbol(token))
+    };
+
+    if let Some(operator) = token_list
+        .len()
+        .checked_sub(2)
+        .and_then(|idx| token_list.get(idx))
+    {
+        let operator = match operator.as_str() {
+            "+" => Operator::Add,
+            "-" => Operator::Sub,
+            "*" => Operator::Mul,
+            "/" => Operator::Div,
+            "%" => Operator::Mod,
+            "^" => Operator::Pow,
+            "==" => Operator::Equal,
+            "!=" => Operator::NotEq,
+            "<" => Operator::LessThan,
+            "<=" => Operator::LessThanEq,
+            ">" => Operator::GreaterThan,
+            ">=" => Operator::GreaterThanEq,
+            "&" => Operator::And,
+            "|" => Operator::Or,
+            _ => return None,
+        };
+        Some(Expr::Infix(Box::new(Infix {
+            operator,
+            values: (
+                parse_expr(token_list.get(..token_list.len() - 2)?.to_vec().join(" "))?,
+                token,
+            ),
+        })))
+    } else {
+        return Some(token);
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,15 @@
+use crate::expr::Expr;
+
+#[derive(Debug, Clone)]
+pub enum Statement {
+    Print(Expr),
+    Input(Expr),
+    Cast(Expr, String),
+    Let(String, Expr),
+    If(Expr, Expr, Option<Expr>),
+    While(Expr, Expr),
+    Lambda(Vec<String>, Expr),
+    Define(String, Vec<String>, Expr),
+    Call(Expr, Vec<Expr>),
+    Fault,
+}

--- a/src/tokenize.rs
+++ b/src/tokenize.rs
@@ -1,0 +1,53 @@
+
+
+pub fn tokenize_expr(input: String, delimiter: Vec<char>) -> Option<Vec<String>> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current_token = String::new();
+    let mut in_parentheses: usize = 0;
+    let mut in_quote = false;
+
+    for c in input.chars() {
+        match c {
+            '(' | '{' | '[' if !in_quote => {
+                current_token.push(c);
+                in_parentheses += 1;
+            }
+            ')' | '}' | ']' if !in_quote => {
+                current_token.push(c);
+                if in_parentheses > 0 {
+                    in_parentheses -= 1;
+                } else {
+                    return None;
+                }
+            }
+            '"' => {
+                in_quote = !in_quote;
+                current_token.push(c);
+            }
+            other => {
+                if delimiter.contains(&other) && !in_quote {
+                    if in_parentheses != 0 {
+                        current_token.push(c);
+                    } else if !current_token.is_empty() {
+                        tokens.push(current_token.clone());
+                        current_token.clear();
+                    }
+                } else {
+                    current_token.push(c);
+                }
+            }
+        }
+    }
+
+    // Syntax error check
+    if in_quote || in_parentheses != 0 {
+        return None;
+    }
+
+    if in_parentheses == 0 && !current_token.is_empty() {
+        tokens.push(current_token.clone());
+        current_token.clear();
+    }
+
+    Some(tokens)
+}

--- a/src/type_enum.rs
+++ b/src/type_enum.rs
@@ -1,0 +1,47 @@
+use crate::{
+    expr,
+    consts
+};
+
+
+#[derive(Debug, Clone)]
+pub enum Type {
+    Number(f64),
+    Symbol(String),
+    Text(String),
+    Function(Vec<String>, Box<expr::Expr>),
+    Null,
+}
+
+impl Type {
+    pub fn get_number(&self) -> f64 {
+        match self {
+            Type::Number(n) => n.to_owned(),
+            Type::Symbol(s) | Type::Text(s) => s.parse().unwrap_or(0.0),
+            Type::Null | Type::Function(_, _) => 0.0,
+        }
+    }
+
+    pub fn get_symbol(&self) -> String {
+        match self {
+            Type::Symbol(s) => s.to_string(),
+            Type::Text(s) => format!("\"{s}\""),
+            Type::Number(n) => n.to_string(),
+            Type::Null => "null".to_string(),
+            Type::Function(args, _) => {
+                format!("func ( {} )", args.join(consts::SPACE[0].to_string().as_str()))
+            }
+        }
+    }
+
+    pub fn get_text(&self) -> String {
+        match self {
+            Type::Number(n) => n.to_string(),
+            Type::Symbol(s) | Type::Text(s) => s.to_string(),
+            Type::Null | Type::Function(_, _) => String::new(),
+        }
+    }
+}
+
+
+

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,7 @@
+use crate::{
+    type_enum::Type,
+    state::Statement
+};
+
+pub type Scope = std::collections::BTreeMap<String, Type>;
+pub type Program = Vec<Statement>;


### PR DESCRIPTION
To improve code organization and readability, I refactored the project by moving most of the functions and relevant code from main.rs into separate files. This separation allows for better maintainability and a clearer structure.

Please review the changes and let me know if any further adjustments are needed.